### PR TITLE
Update GATLING-JAVA-GRADLE-SETUP.md

### DIFF
--- a/gatling-java-gradle-setup/GATLING-JAVA-GRADLE-SETUP.md
+++ b/gatling-java-gradle-setup/GATLING-JAVA-GRADLE-SETUP.md
@@ -55,7 +55,6 @@ dependencies {
     implementation("io.gatling:gatling-core:3.7.6")
     implementation("io.gatling:gatling-http:3.7.6")
     implementation("io.gatling:gatling-app:3.7.6")
-    implementation("io.gatling:gatling-metrics:2.3.1")
     gatlingRuntimeOnly("io.gatling:gatling-charts:3.7.6")
     gatlingRuntimeOnly("io.gatling.highcharts:gatling-charts-highcharts:3.7.6")
     //endregion


### PR DESCRIPTION
Remove gatling-metrics which is an old module from Gatling 2 that no longer exists in Gatling 3 and that can cause classpath issues as it pull Scala 2.12 while Gatling 3.5+ requires Scala 2.13.